### PR TITLE
Added bitness and endianness

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,13 @@ Usage is super simple::
 
     >>> its.osx
     True
+    
+    >>> its.bit64
+    True
+    
+    >>> its.little_endian
+    True
+
 
 
 Installation

--- a/its.py
+++ b/its.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-is.py
+its.py
 ~~~~~
 
 System environment flags.
@@ -9,6 +9,7 @@ System environment flags.
 
 
 import sys
+import struct
 
 # -------
 # Pythons
@@ -75,3 +76,23 @@ osx = ('darwin' in str(sys.platform).lower())
 hpux = ('hpux' in str(sys.platform).lower())   # Complete guess.
 solaris = ('solaris' in str(sys.platform).lower())   # Complete guess.
 
+
+# ---------
+# Bitness
+# ---------
+
+
+# 32-bit vs. 64-bit
+_void_ptr_size = struct.calcsize('P')
+bit32 = _void_ptr_size * 8 == 32
+bit64 = _void_ptr_size * 8 == 64
+
+
+# ---------
+# Endianness
+# ---------
+
+
+# little vs. big endian
+little_endian = sys.byteorder == 'little'
+big_endian = sys.byteorder == 'big'


### PR DESCRIPTION
Verified bitness on my mac:

```
jterrace@frazzle:~/its.py$ arch -i386 /usr/bin/python2.7
Python 2.7.1 (r271:86832, Jun 16 2011, 16:59:06) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import its
>>> its.bit32
True
>>> its.bit64
False
>>> its.little_endian
True
>>> its.big_endian
False

jterrace@frazzle:~/its.py$ /usr/bin/python2.7
Python 2.7.1 (r271:86832, Jun 16 2011, 16:59:05) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import its
>>> its.bit32
False
>>> its.bit64
True
>>> its.little_endian
True
>>> its.big_endian
False
```
