### PR TITLE
Fix Solaris check

### DIFF
--- a/its.py
+++ b/its.py
@@ -74,7 +74,7 @@ windows = 'win32' in str(sys.platform).lower()
 linux = ('linux' in str(sys.platform).lower())
 osx = ('darwin' in str(sys.platform).lower())
 hpux = ('hpux' in str(sys.platform).lower())   # Complete guess.
-solaris = ('solaris' in str(sys.platform).lower())   # Complete guess.
+solaris = ('sunos' in str(sys.platform).lower())   # Complete guess.
 
 
 # ---------

--- a/its.py
+++ b/its.py
@@ -74,7 +74,7 @@ windows = 'win32' in str(sys.platform).lower()
 linux = ('linux' in str(sys.platform).lower())
 osx = ('darwin' in str(sys.platform).lower())
 hpux = ('hpux' in str(sys.platform).lower())   # Complete guess.
-solaris = ('sunos' in str(sys.platform).lower())   # Complete guess.
+solaris = ('sunos' in str(sys.platform).lower())
 
 
 # ---------


### PR DESCRIPTION
The Solaris platform is reported as "sunos<N>", e.g.: 

$ python -c 'import sys; print sys.platform'
sunos5
